### PR TITLE
Change 'debrisVolumeGallons' to 'debrisVolumeLiters' when posting trap visit

### DIFF
--- a/src/screens/formScreens/IncompleteSections.tsx
+++ b/src/screens/formScreens/IncompleteSections.tsx
@@ -222,7 +222,7 @@ const IncompleteSections = ({
           : null,
       inHalfConeConfiguration:
         trapOperationsState.values.coneSetting === 'half' ? true : false,
-      debrisVolumeGallons: trapPostProcessingState.values.debrisVolume
+      debrisVolumeLiters: trapPostProcessingState.values.debrisVolume
         ? parseInt(trapPostProcessingState.values.debrisVolume)
         : null,
       qcCompleted: null,


### PR DESCRIPTION
Fixes current issue where we can't post trap-visits