### PR TITLE
Adjust validation schema to allow for optional rpm values

### DIFF
--- a/src/utils/helpers/yupValidations.ts
+++ b/src/utils/helpers/yupValidations.ts
@@ -57,10 +57,12 @@ export const trapOperationsSchema = yup.object().shape({
     .typeError('Input must be a number'),
   rpm2: yup
     .number()
+    .nullable()
     // .required('Measurement 2 required')
     .typeError('Input must be a number'),
   rpm3: yup
     .number()
+    .nullable()
     // .required('Measurement 3 required')
     .typeError('Input must be a number'),
 })
@@ -76,12 +78,14 @@ export const trapPostProcessingSchema = yup.object().shape({
     .typeError('Input must be a number'),
   rpm2: yup
     .number()
+    .nullable()
     // .required('Measurement 2 required')
     .typeError('Input must be a number'),
   rpm3: yup
     .number()
-    .typeError('Input must be a number')
+    .nullable()
     // .required('Measurement 3 required'),
+    .typeError('Input must be a number'),
 })
 
 export const fishProcessingSchema = yup.object().shape({


### PR DESCRIPTION
Issue: _Cone revolutions - start and end (rpms) is not working as it should. Currently it states that only one measurement is required but does not allow you to go next unless all are inputed._

Closes #135 