### PR TITLE
Adjust margin on tab error badge

### DIFF
--- a/src/components/form/TabBar.tsx
+++ b/src/components/form/TabBar.tsx
@@ -129,9 +129,7 @@ const TabBar = ({
                   <Badge
                     colorScheme='danger'
                     rounded='full'
-                    mb={'50px'}
-                    ml={-9}
-                    mr={3}
+                    mr={2}
                     zIndex={1}
                     variant='solid'
                     alignSelf='flex-end'


### PR DESCRIPTION
Addresses this checkbox:
```
Tabs get misaligned with incomplete section notification
``` 
On issue: #254